### PR TITLE
Added a timeout transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ use the timeout simulating transport.
 * `mail.transport.protocol` -- set this to `timeout`
 * `timeout.connectionTimeout` -- set this to a value greater 0 to simulate a timeout during connection creation
 * `timeout.messageTimeout` -- set this to a value greater 0 to simulate a timeout during message sending
+
 Note that the TimeoutTransport derives from the FileTransport class and therefore file transport properties may also 
 be used. Setting both `timeout.connectionTimeout` and `timeout.messageTimeout` to values less than 0 effectively
 causes the TimeoutTransport to act as a pass through to FileTransport.

--- a/README.md
+++ b/README.md
@@ -273,3 +273,21 @@ Add a resource reference for the mail resource to your application's
 
 </jboss:jboss-web>
 ```
+
+Using Timeout Transport
+-----------------------
+The TimeoutTransport allows for the simulation of timeout errors on the connection and message sending. 
+The operations to connect and sendMessage will wait for the defined time and then throw a MessagingException.
+
+### Configuration Properties
+
+These properties must be set on the `javax.mail.Session` object in order to 
+use the timeout simulating transport.
+
+* `mail.transport.protocol` -- set this to `timeout`
+* `timeout.connectionTimeout` -- set this to a value greater 0 to simulate a timeout during connection creation
+* `timeout.messageTimeout` -- set this to a value greater 0 to simulate a timeout during message sending
+Note that the TimeoutTransport derives from the FileTransport class and therefore file transport properties may also 
+be used. Setting both `timeout.connectionTimeout` and `timeout.messageTimeout` to values less than 0 effectively
+causes the TimeoutTransport to act as a pass through to FileTransport.
+See TimeoutThrowingTransportTest for an example usage.

--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,14 @@
                 <format>tar.gz</format>
                 <format>zip</format>
               </formats>
+              <tarLongFileMode>posix</tarLongFileMode>
               <descriptors>
                 <descriptor>src/assembly/modules-assembly.xml</descriptor>
               </descriptors>
             </configuration>
           </execution>
         </executions>
+
       </plugin>
     </plugins>  
   </build>

--- a/src/main/java/org/soulwing/mail/transport/TimeoutThrowingTransport.java
+++ b/src/main/java/org/soulwing/mail/transport/TimeoutThrowingTransport.java
@@ -31,7 +31,7 @@ import javax.mail.URLName;
  *
  * @author Carl Harris
  */
-public class TimeoutThrowingTransport extends Transport {
+public class TimeoutThrowingTransport extends FileTransport {
   private final long connectionTimeout;
   private final long messageTimeout;
 
@@ -56,13 +56,13 @@ public class TimeoutThrowingTransport extends Transport {
       throw new MessagingException("Timeout exception connecting to host");
     }
 
-    super.connect("timeout host", -1, null, null);
+    super.connect(host, -1, user, password);
   }
 
   @Override
   protected boolean protocolConnect(String host, int port, String user, String password)
       throws MessagingException {
-    return true;
+    return super.protocolConnect(host, port, user, password);
   }
 
   @Override
@@ -76,6 +76,7 @@ public class TimeoutThrowingTransport extends Transport {
       }
       throw new MessagingException("Timeout exception sending message");
     }
+    super.sendMessage(message, addresses);
   }
 
 }

--- a/src/main/java/org/soulwing/mail/transport/TimeoutThrowingTransport.java
+++ b/src/main/java/org/soulwing/mail/transport/TimeoutThrowingTransport.java
@@ -1,0 +1,81 @@
+/*
+ * File created on Nov 5, 2018
+ *
+ * Copyright (c) 2018 Carl Harris, Jr
+ * and others as noted
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.soulwing.mail.transport;
+
+import javax.mail.Address;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.URLName;
+
+/**
+ * A JavaMail {@link Transport} that throws an exception on an
+ * attempt to send a message.
+ *
+ * @author Carl Harris
+ */
+public class TimeoutThrowingTransport extends Transport {
+  private final long connectionTimeout;
+  private final long messageTimeout;
+
+  public TimeoutThrowingTransport(Session session, URLName urlname) {
+    super(session, urlname);
+
+    String connectionTimeoutValue = session.getProperty("timeout.connectionTimeout");
+    String messageTimeoutValue = session.getProperty("timeout.messageTimeout");
+
+    connectionTimeout = connectionTimeoutValue == null ? -1 : Long.valueOf(connectionTimeoutValue);
+    messageTimeout = messageTimeoutValue == null ? -1 : Long.valueOf(messageTimeoutValue);
+  }
+
+  @Override
+  public void connect(String host, String user, String password) throws MessagingException {
+    if (connectionTimeout > 0) {
+      try {
+        Thread.currentThread().sleep(connectionTimeout);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      throw new MessagingException("Timeout exception connecting to host");
+    }
+
+    super.connect("timeout host", -1, null, null);
+  }
+
+  @Override
+  protected boolean protocolConnect(String host, int port, String user, String password)
+      throws MessagingException {
+    return true;
+  }
+
+  @Override
+  public void sendMessage(Message message, Address[] addresses)
+      throws MessagingException {
+    if (messageTimeout > 0) {
+      try {
+        Thread.currentThread().sleep(messageTimeout);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      throw new MessagingException("Timeout exception sending message");
+    }
+  }
+
+}

--- a/src/main/resources/META-INF/javamail.providers
+++ b/src/main/resources/META-INF/javamail.providers
@@ -1,3 +1,4 @@
 protocol=file; type=transport; class=org.soulwing.mail.transport.FileTransport; vendor=Soulwing.ORG
 protocol=rcpt; type=transport; class=org.soulwing.mail.transport.FixedRecipientTransport; vendor=Soulwing.ORG
 protocol=error; type=transport; class=org.soulwing.mail.transport.ErrorThrowingTransport; vendor=Soulwing.ORG
+protocol=timeout; type=transport; class=org.soulwing.mail.transport.TimeoutThrowingTransport; vendor=Soulwing.ORG

--- a/src/test/java/org/soulwing/mail/transport/AbstractEventListener.java
+++ b/src/test/java/org/soulwing/mail/transport/AbstractEventListener.java
@@ -1,4 +1,46 @@
 package org.soulwing.mail.transport;
 
-public class AbstractEventListener {
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+abstract class AbstractEventListener<T> {
+
+  private final Lock lock = new ReentrantLock();
+  private final Condition readyCondition = lock.newCondition();
+
+  private T event;
+
+  void reset() {
+    event = null;
+  }
+
+  T awaitEvent(final long wait, final long maxWait) throws InterruptedException {
+    lock.lock();
+    try {
+      final long start = System.currentTimeMillis();
+      long now = start;
+      while (event == null && (now - start) < maxWait) {
+        readyCondition.await(wait, TimeUnit.MILLISECONDS);
+        now = System.currentTimeMillis();
+      }
+      return event;
+    }
+    finally {
+      lock.unlock();
+    }
+  }
+
+  void receiveEvent(T event) {
+    lock.lock();
+    try {
+      this.event = event;
+      readyCondition.signalAll();
+    }
+    finally {
+      lock.unlock();
+    }
+  }
+
 }

--- a/src/test/java/org/soulwing/mail/transport/AbstractEventListener.java
+++ b/src/test/java/org/soulwing/mail/transport/AbstractEventListener.java
@@ -1,0 +1,4 @@
+package org.soulwing.mail.transport;
+
+public class AbstractEventListener {
+}

--- a/src/test/java/org/soulwing/mail/transport/MockConnectionListener.java
+++ b/src/test/java/org/soulwing/mail/transport/MockConnectionListener.java
@@ -1,4 +1,25 @@
 package org.soulwing.mail.transport;
 
-public class MockConnectionListener {
+import javax.mail.event.ConnectionEvent;
+import javax.mail.event.ConnectionListener;
+
+class MockConnectionListener
+    extends AbstractEventListener<ConnectionEvent>
+    implements ConnectionListener {
+
+  @Override
+  public void opened(ConnectionEvent connectionEvent) {
+    receiveEvent(connectionEvent);
+  }
+
+  @Override
+  public void disconnected(ConnectionEvent connectionEvent) {
+    receiveEvent(connectionEvent);
+  }
+
+  @Override
+  public void closed(ConnectionEvent connectionEvent) {
+    receiveEvent(connectionEvent);
+  }
+
 }

--- a/src/test/java/org/soulwing/mail/transport/MockConnectionListener.java
+++ b/src/test/java/org/soulwing/mail/transport/MockConnectionListener.java
@@ -1,0 +1,4 @@
+package org.soulwing.mail.transport;
+
+public class MockConnectionListener {
+}

--- a/src/test/java/org/soulwing/mail/transport/MockTransportListener.java
+++ b/src/test/java/org/soulwing/mail/transport/MockTransportListener.java
@@ -1,0 +1,4 @@
+package org.soulwing.mail.transport;
+
+public class MockTransportListener {
+}

--- a/src/test/java/org/soulwing/mail/transport/MockTransportListener.java
+++ b/src/test/java/org/soulwing/mail/transport/MockTransportListener.java
@@ -1,4 +1,25 @@
 package org.soulwing.mail.transport;
 
-public class MockTransportListener {
+import javax.mail.event.TransportEvent;
+import javax.mail.event.TransportListener;
+
+class MockTransportListener
+    extends AbstractEventListener<TransportEvent>
+    implements TransportListener {
+
+  @Override
+  public void messageDelivered(TransportEvent transportEvent) {
+    receiveEvent(transportEvent);
+  }
+
+  @Override
+  public void messageNotDelivered(TransportEvent transportEvent) {
+    receiveEvent(transportEvent);
+  }
+
+  @Override
+  public void messagePartiallyDelivered(TransportEvent transportEvent) {
+    receiveEvent(transportEvent);
+  }
+
 }

--- a/src/test/java/org/soulwing/mail/transport/TimeoutThrowingTransportTest.java
+++ b/src/test/java/org/soulwing/mail/transport/TimeoutThrowingTransportTest.java
@@ -1,0 +1,207 @@
+/*
+ * File created on Nov 5, 2018
+ *
+ * Copyright (c) 2018 Carl Harris, Jr
+ * and others as noted
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.soulwing.mail.transport;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.event.ConnectionEvent;
+import javax.mail.event.ConnectionListener;
+import javax.mail.event.TransportEvent;
+import javax.mail.event.TransportListener;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMessage.RecipientType;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ErrorThrowingTransport}.
+ *
+ * @author Carl Harris
+ */
+public class ErrorThrowingTransportTest {
+
+  private static final long LISTENER_WAIT = 500;
+  private static final long MAX_LISTENER_WAIT = 10*LISTENER_WAIT;
+
+  private SessionFactory sessionFactory;
+
+  @Before
+  public void setUp() throws Exception {
+    sessionFactory = new SessionFactory(defaultProperties());
+  }
+
+  @Test
+  public void testConnect() throws Exception {
+    Session session = sessionFactory.newSession();
+    Transport transport = session.getTransport();
+    MockConnectionListener listener = new MockConnectionListener();
+    transport.addConnectionListener(listener);
+
+    transport.connect();
+
+    ConnectionEvent event = listener.awaitEvent();
+    assertThat(event, is(not(nullValue())));
+    assertThat(event.getType(), is(equalTo(ConnectionEvent.OPENED)));
+    listener.reset();
+    transport.close();
+    event = listener.awaitEvent();
+    assertThat(event, is(not(nullValue())));
+    assertThat(event.getType(), is(equalTo(ConnectionEvent.CLOSED)));
+  }
+
+  @Test(expected = MessagingException.class)
+  public void testSendMessage() throws Exception {
+    Session session = sessionFactory.newSession();
+    Transport transport = session.getTransport();
+    MockTransportListener listener = new MockTransportListener();
+    transport.addTransportListener(listener);
+    Message message = MessageFactory.newMessage("Test message", session);
+    transport.sendMessage(message, message.getAllRecipients());
+  }
+
+  @Test
+  public void testSendMessageWithCustomErrorMessage() throws Exception {
+    Session session = sessionFactory.newSession();
+    Transport transport = session.getTransport();
+    MockTransportListener listener = new MockTransportListener();
+    transport.addTransportListener(listener);
+    Message message = MessageFactory.newMessage("Test message", session);
+    message.setHeader(ErrorHeader.ERROR_HEADER, "Test error");
+    try {
+      transport.sendMessage(message, message.getAllRecipients());
+      fail("expected MessagingException");
+    }
+    catch (MessagingException ex) {
+      assertThat(ex.getMessage(), is(equalTo("Test error")));
+    }
+  }
+
+  private static Properties defaultProperties() {
+    final Properties properties = new Properties();
+    properties.setProperty("mail.transport.protocol", "error");
+    return properties;
+  }
+
+  private static abstract class AbstractEventListener<T> {
+
+    private final Lock lock = new ReentrantLock();
+    private final Condition readyCondition = lock.newCondition();
+
+    private T event;
+
+    void reset() {
+      event = null;
+    }
+
+    T awaitEvent() throws InterruptedException {
+      lock.lock();
+      try {
+        final long start = System.currentTimeMillis();
+        long now = start;
+        while (event == null && (now - start) < MAX_LISTENER_WAIT) {
+          readyCondition.await(LISTENER_WAIT, TimeUnit.MILLISECONDS);
+          now = System.currentTimeMillis();
+        }
+        return event;
+      }
+      finally {
+        lock.unlock();
+      }
+    }
+
+    void receiveEvent(T event) {
+      lock.lock();
+      try {
+        this.event = event;
+        readyCondition.signalAll();
+      }
+      finally {
+        lock.unlock();
+      }
+    }
+
+  }
+
+  private static class MockConnectionListener
+      extends AbstractEventListener<ConnectionEvent>
+      implements ConnectionListener {
+
+    @Override
+    public void opened(ConnectionEvent connectionEvent) {
+      receiveEvent(connectionEvent);
+    }
+
+    @Override
+    public void disconnected(ConnectionEvent connectionEvent) {
+      receiveEvent(connectionEvent);
+    }
+
+    @Override
+    public void closed(ConnectionEvent connectionEvent) {
+      receiveEvent(connectionEvent);
+    }
+
+  }
+
+  private static class MockTransportListener
+      extends AbstractEventListener<TransportEvent>
+      implements TransportListener {
+
+    @Override
+    public void messageDelivered(TransportEvent transportEvent) {
+      receiveEvent(transportEvent);
+    }
+
+    @Override
+    public void messageNotDelivered(TransportEvent transportEvent) {
+      receiveEvent(transportEvent);
+    }
+
+    @Override
+    public void messagePartiallyDelivered(TransportEvent transportEvent) {
+      receiveEvent(transportEvent);
+    }
+
+  }
+
+}
+
+

--- a/src/test/java/org/soulwing/mail/transport/TimeoutThrowingTransportTest.java
+++ b/src/test/java/org/soulwing/mail/transport/TimeoutThrowingTransportTest.java
@@ -18,24 +18,10 @@
  */
 package org.soulwing.mail.transport;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.fail;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -44,162 +30,63 @@ import javax.mail.event.ConnectionEvent;
 import javax.mail.event.ConnectionListener;
 import javax.mail.event.TransportEvent;
 import javax.mail.event.TransportListener;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMessage.RecipientType;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link ErrorThrowingTransport}.
  *
  * @author Carl Harris
  */
-public class ErrorThrowingTransportTest {
+public class TimeoutThrowingTransportTest {
 
   private static final long LISTENER_WAIT = 500;
   private static final long MAX_LISTENER_WAIT = 10*LISTENER_WAIT;
 
-  private SessionFactory sessionFactory;
-
-  @Before
-  public void setUp() throws Exception {
-    sessionFactory = new SessionFactory(defaultProperties());
-  }
-
-  @Test
+  @Test(expected = MessagingException.class)
   public void testConnect() throws Exception {
+    final Properties properties = new Properties();
+    properties.setProperty("mail.transport.protocol", "timeout");
+    properties.setProperty("timeout.connectionTimeout", "10");
+    SessionFactory sessionFactory = new SessionFactory(properties);
+
     Session session = sessionFactory.newSession();
     Transport transport = session.getTransport();
     MockConnectionListener listener = new MockConnectionListener();
     transport.addConnectionListener(listener);
 
     transport.connect();
-
-    ConnectionEvent event = listener.awaitEvent();
-    assertThat(event, is(not(nullValue())));
-    assertThat(event.getType(), is(equalTo(ConnectionEvent.OPENED)));
-    listener.reset();
-    transport.close();
-    event = listener.awaitEvent();
-    assertThat(event, is(not(nullValue())));
-    assertThat(event.getType(), is(equalTo(ConnectionEvent.CLOSED)));
   }
 
   @Test(expected = MessagingException.class)
   public void testSendMessage() throws Exception {
-    Session session = sessionFactory.newSession();
+    final Properties properties = new Properties();
+    properties.setProperty("mail.transport.protocol", "timeout");
+    properties.setProperty("timeout.connectionTimeout", "-1");
+    properties.setProperty("timeout.messageTimeout", "10");
+    SessionFactory sessionFactory = new SessionFactory(properties);
+
+    Session session = null;
+    try {
+      session = sessionFactory.newSession();
+    } catch (MessagingException mX) {
+      Assert.fail("Exception should NOT have been thrown on connection");
+    }
     Transport transport = session.getTransport();
-    MockTransportListener listener = new MockTransportListener();
+    org.soulwing.mail.transport.MockTransportListener listener = new org.soulwing.mail.transport.MockTransportListener();
     transport.addTransportListener(listener);
     Message message = MessageFactory.newMessage("Test message", session);
     transport.sendMessage(message, message.getAllRecipients());
-  }
-
-  @Test
-  public void testSendMessageWithCustomErrorMessage() throws Exception {
-    Session session = sessionFactory.newSession();
-    Transport transport = session.getTransport();
-    MockTransportListener listener = new MockTransportListener();
-    transport.addTransportListener(listener);
-    Message message = MessageFactory.newMessage("Test message", session);
-    message.setHeader(ErrorHeader.ERROR_HEADER, "Test error");
-    try {
-      transport.sendMessage(message, message.getAllRecipients());
-      fail("expected MessagingException");
-    }
-    catch (MessagingException ex) {
-      assertThat(ex.getMessage(), is(equalTo("Test error")));
-    }
-  }
-
-  private static Properties defaultProperties() {
-    final Properties properties = new Properties();
-    properties.setProperty("mail.transport.protocol", "error");
-    return properties;
-  }
-
-  private static abstract class AbstractEventListener<T> {
-
-    private final Lock lock = new ReentrantLock();
-    private final Condition readyCondition = lock.newCondition();
-
-    private T event;
-
-    void reset() {
-      event = null;
-    }
-
-    T awaitEvent() throws InterruptedException {
-      lock.lock();
-      try {
-        final long start = System.currentTimeMillis();
-        long now = start;
-        while (event == null && (now - start) < MAX_LISTENER_WAIT) {
-          readyCondition.await(LISTENER_WAIT, TimeUnit.MILLISECONDS);
-          now = System.currentTimeMillis();
-        }
-        return event;
-      }
-      finally {
-        lock.unlock();
-      }
-    }
-
-    void receiveEvent(T event) {
-      lock.lock();
-      try {
-        this.event = event;
-        readyCondition.signalAll();
-      }
-      finally {
-        lock.unlock();
-      }
-    }
-
-  }
-
-  private static class MockConnectionListener
-      extends AbstractEventListener<ConnectionEvent>
-      implements ConnectionListener {
-
-    @Override
-    public void opened(ConnectionEvent connectionEvent) {
-      receiveEvent(connectionEvent);
-    }
-
-    @Override
-    public void disconnected(ConnectionEvent connectionEvent) {
-      receiveEvent(connectionEvent);
-    }
-
-    @Override
-    public void closed(ConnectionEvent connectionEvent) {
-      receiveEvent(connectionEvent);
-    }
-
-  }
-
-  private static class MockTransportListener
-      extends AbstractEventListener<TransportEvent>
-      implements TransportListener {
-
-    @Override
-    public void messageDelivered(TransportEvent transportEvent) {
-      receiveEvent(transportEvent);
-    }
-
-    @Override
-    public void messageNotDelivered(TransportEvent transportEvent) {
-      receiveEvent(transportEvent);
-    }
-
-    @Override
-    public void messagePartiallyDelivered(TransportEvent transportEvent) {
-      receiveEvent(transportEvent);
-    }
-
   }
 
 }


### PR DESCRIPTION
I have an unusual test case where I need to simulate a timeout from SMTP on a thread that itself has a timeout. Adding a TimeoutTransport to your library was the simplest way for me to do that. Hope it is useful.
BTW, I needed to add <tarLongFileMode>posix<tarLongFileMode> to the maven-assembly-plugin in the POM, it was failing to build on OSX 10.14.6.